### PR TITLE
Fix the ERROR: Could not install packages due to an EnvironmentError:

### DIFF
--- a/install_rss_simulator.sh
+++ b/install_rss_simulator.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-pip install dist/rss_simulator_nvidia-0.0.1-py2.py3-none-any.whl
+pip install dist/rss_simulator_nvidia-0.0.2-py2.py3-none-any.whl


### PR DESCRIPTION
[Errno 2] No such file or directory: '/tmp/rss_simulator_nvidia/dist/rss_simulator_nvidia-0.0.1-py2.py3-none-any.whl'

I am having this error when running `install_rss_simulator.sh`. The package we trying to install in `install_rss_simulator.sh` is not present in the `./dist` directory.

Signed-off-by: alihasanahmedkhan <alihasanahmedkhan@gmail.com>